### PR TITLE
fix(S3Backend): Correct types for allowedAccountIds & forbiddenAccountIds

### DIFF
--- a/packages/cdktf/lib/backends/s3-backend.ts
+++ b/packages/cdktf/lib/backends/s3-backend.ts
@@ -69,7 +69,7 @@ export interface S3BackendConfig {
    * (Optional) List of allowed AWS account IDs to prevent potential destruction of a live environment.
    * Conflicts with forbidden_account_ids.
    */
-  readonly allowedAccountIds?: string;
+  readonly allowedAccountIds?: string[];
   /**
    * (Optional) File containing custom root and intermediate certificates.
    * Can also be set using the AWS_CA_BUNDLE environment variable.
@@ -91,7 +91,7 @@ export interface S3BackendConfig {
    * (Optional) List of forbidden AWS account IDs to prevent potential destruction of a live environment.
    * Conflicts with allowed_account_ids.
    */
-  readonly forbiddenAccountIds?: string;
+  readonly forbiddenAccountIds?: string[];
   /**
    * (Optional) URL of a proxy to use for HTTP requests when accessing the AWS API.
    * Can also be set using the HTTP_PROXY or http_proxy environment variables.


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

No related issue as it is only a simple 2-line change. Can create one if required.

### Description

When providing these fields as a string rather than a list of strings, Terraform throws an error. This PR updates the types to be a list of strings, to allow specifying the format that Terraform requires (similar to the other config keys such as sharedConfigFiles, sharedCredentialsFiles etc).

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation if applicable~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works if applicable~
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
